### PR TITLE
Add semantic-release as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "dependencies": {
     "@semantic-release/npm": "^9.0.0",
     "require-reload": "^0.2.2"
+  },
+  "peerDependencies": {
+    "semantic-release": "^19.x"
   }
 }


### PR DESCRIPTION
When running `yarn install` with yarn version 3.2.0, yarn complained:
`@amanda-mitchell/semantic-release-npm-multiple@npm:3.2.0 doesn't provide semantic-release (p32ae4), requested by @semantic-release/npm`

Explicitly adding `semantic-release` as peerDependency fixes this