### PR TITLE
fix(deps-peer): Allow semantic-release >= 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "@semantic-release/npm": "^13.0.0"
   },
   "peerDependencies": {
-    "semantic-release": "^19.x"
+    "semantic-release": ">=19.0.0"
   }
 }

--- a/release.config.js
+++ b/release.config.js
@@ -4,7 +4,7 @@ export default {
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     [
-      (await import('./index.js')).default,
+      (await import('@amanda-mitchell/semantic-release-npm-multiple')).default,
       { registries: { github: {}, public: {} } },
     ],
     '@semantic-release/github',


### PR DESCRIPTION
See https://github.com/semantic-release/npm/blob/01f1cd0/package.json#L90-L92 for reference.

Fixes #331
Fixes #358

---

The previous range `^19.x` was not respected when dogfooding (e.g. in `@amanda-mitchell/semantic-release-npm-multiple`'s own release workflows and Semantic Release runs) which led to the `semantic-release` dependencies to be upgraded by Dependabot to versions disallowed by the `peerDependencies` entry. This means `@amanda-mitchell/semantic-release-npm-multiple`'s could continue, but the conflict would break consumers' release pipelines as seen in #331 , #358.

Changing the peerDeps semver range from `^` (MINOR.PATCH) to `>=` (MAJOR.MINOR.PATCH) as is the case in first-party Semantic-Release plugins ([npm](https://github.com/semantic-release/npm/blob/01f1cd0/package.json#L90-L92), [gitlab](https://github.com/semantic-release/gitlab/blob/da5813bdf6937628fea78ef7f83f697bc5f7021a/package.json#L78-L80), et cetera) will fix this dependency conflict.